### PR TITLE
Merge loggedErrorResponse function into errorResponse function

### DIFF
--- a/src/main/kotlin/no/liflig/http4k/setup/Globals.kt
+++ b/src/main/kotlin/no/liflig/http4k/setup/Globals.kt
@@ -20,38 +20,28 @@ fun Request.attachThrowableToLog(throwable: Throwable) {
 /**
  * Returns a standardized error response following the 'Problem Details' specification.
  *
+ * If a [cause] throwable is given, attaches it to the request log.
+ *
  * @see <a href="https://datatracker.ietf.org/doc/html/rfc7807">Problem Details specification</a>
  */
 fun errorResponse(
     request: Request,
     status: Status,
     title: String,
-    detail: String? = null
-): Response =
-    Response(status)
-        .with(
-            ErrorResponseBody.bodyLens of
-                ErrorResponseBody(
-                    title = title,
-                    detail = detail,
-                    status = status.code,
-                    instance = request.uri.path,
-                ),
-        )
-
-/**
- * Returns a standardized error response following the 'Problem Details' specification, and puts the
- * given throwable in the request context for logging.
- *
- * @see <a href="https://datatracker.ietf.org/doc/html/rfc7807">Problem Details specification</a>
- */
-fun loggedErrorResponse(
-    request: Request,
-    status: Status,
-    title: String,
     detail: String? = null,
-    throwable: Throwable? = null
+    cause: Throwable? = null
 ): Response {
-  throwable?.run { request.attachThrowableToLog(this) }
-  return errorResponse(request, status, title, detail)
+  if (cause != null) {
+    request.attachThrowableToLog(cause)
+  }
+  return Response(status)
+      .with(
+          ErrorResponseBody.bodyLens of
+              ErrorResponseBody(
+                  title = title,
+                  detail = detail,
+                  status = status.code,
+                  instance = request.uri.path,
+              ),
+      )
 }


### PR DESCRIPTION
The only purpose of the `loggedErrorResponse` function is to take an additional optional Throwable argument, and then call `errorResponse` with the remaining arguments. This optional throwable argument might as well be part of `errorResponse`. I think this is better, for two reasons:

1. `loggedErrorResponse` indicates that it logs the given error, when in fact both it and `errorResponse` do that as part of the normal request log; the `logged` variant just attaches the optional Throwable.
2. By making the optional Throwable an argument of `errorResponse`, it becomes more discoverable: users of this API can see from the `errorResponse` signature and docs that they can attach a Throwable cause if they have it, rather than having to find the separate `loggedErrorResponse` function.