### PR TITLE
Add MultiValueQuery lens for accepting comma-separated query params

### DIFF
--- a/src/main/kotlin/no/liflig/http4k/setup/lenses/MultiValueQuery.kt
+++ b/src/main/kotlin/no/liflig/http4k/setup/lenses/MultiValueQuery.kt
@@ -1,0 +1,67 @@
+package no.liflig.http4k.setup.lenses
+
+import org.http4k.core.Request
+import org.http4k.lens.BiDiLensSpec
+import org.http4k.lens.LensGet
+import org.http4k.lens.LensSet
+import org.http4k.lens.LensSpec
+import org.http4k.lens.ParamMeta
+
+/**
+ * There is no defined standard for passing multiple values for a query parameter in a URL. Web
+ * servers typically allow one or both of these formats:
+ * - `https://example.com?queryParam=value1&queryParam=value2`
+ * - `https://example.com?queryParam=value1,value2`
+ *
+ * http4k (which we use on the backend) expects list query params on the first format (when using
+ * `Query.multi`), but RTK Query (which we use on the frontend) passes list query params on the
+ * second format. Thus, when we pass `queryParam` from an RTK Query client to an http4k server,
+ * http4k sees it as a single parameter with value `"value1,value2"`.
+ *
+ * This lens works like [org.http4k.lens.Query], except it accepts query params on both the first
+ * and the second format, i.e. multiple query params with the same key or a single query param with
+ * comma-separated values.
+ */
+object MultiValueQuery :
+    BiDiLensSpec<Request, List<String>>(
+        location = "query",
+        ParamMeta.ArrayParam(ParamMeta.StringParam),
+        LensGet { paramName, request ->
+          var params = request.queries(paramName).filterNotNull()
+          // If we receive a single query param, we parse it as a comma-separated list. But if we
+          // receive multiple, we assume that clients don't mix multiple params with comma-separated
+          // values, i.e. `queryParam=value1&queryParam=value2,value3`. In this case, the comma in
+          // the second param is more likely part of the value, so we don't split it.
+          if (params.size == 1) {
+            params = params.first().split(",")
+          }
+          listOf(params)
+        },
+        LensSet { paramName, params, request ->
+          val requestWithoutQuery = request.removeQuery(paramName)
+          requestWithoutQuery.query(paramName, params.asSequence().flatten().joinToString(","))
+        },
+    ) {
+  /**
+   * Works like [LensSpec.map], except the mapper function applies to each value of the query param,
+   * so you don't have to do `MultiValueQuery.map { values -> values.map { ... } }` yourself.
+   */
+  fun <T> mapValues(mapper: (String) -> T): LensSpec<Request, List<T>> {
+    return this.map { values -> values.map(mapper) }
+  }
+
+  /**
+   * Works like [BiDiLensSpec.map], except the mapper functions apply to each value of the query
+   * param, so you don't have to do `MultiValueQuery.map({ values -> values.map { ... } }, { values
+   * -> values.map { ... } })` yourself.
+   */
+  fun <T> mapValues(
+      incoming: (String) -> T,
+      outgoing: (T) -> String
+  ): BiDiLensSpec<Request, List<T>> {
+    return this.map(
+        { incomingValues -> incomingValues.map(incoming) },
+        { outgoingValues -> outgoingValues.map(outgoing) },
+    )
+  }
+}

--- a/src/test/kotlin/no/liflig/http4k/setup/http4k/MultiValueQueryTest.kt
+++ b/src/test/kotlin/no/liflig/http4k/setup/http4k/MultiValueQueryTest.kt
@@ -1,0 +1,73 @@
+package no.liflig.http4k.setup.http4k
+
+import io.kotest.matchers.shouldBe
+import kotlinx.serialization.Serializable
+import no.liflig.http4k.setup.lenses.MultiValueQuery
+import org.http4k.core.Method
+import org.http4k.core.Request
+import org.http4k.core.RequestContexts
+import org.http4k.core.Response
+import org.http4k.core.Status
+import org.http4k.core.then
+import org.http4k.filter.ServerFilters
+import org.http4k.format.KotlinxSerialization.json
+import org.junit.jupiter.api.Test
+
+class MultiValueQueryTest {
+  @Test
+  fun `MultiValueQuery accepts query params on both param=value1,value2 and param=value1&param=value2 formats`() {
+    val queryParam = MultiValueQuery.required("param")
+
+    val handler =
+        ServerFilters.InitialiseRequestContext(RequestContexts()).then { request ->
+          val values = queryParam(request)
+          Response(Status.OK).json(values)
+        }
+
+    for (url in listOf("/some/url?param=value1,value2", "/some/url?param=value1&param=value2")) {
+      val response = handler(Request(Method.GET, url))
+      response.status shouldBe Status.OK
+      val responseBody = response.json<List<String>>()
+      responseBody shouldBe listOf("value1", "value2")
+    }
+  }
+
+  @Serializable @JvmInline value class Id(val value: String)
+
+  @Test
+  fun `mapValues maps values correctly`() {
+    val idsQuery = MultiValueQuery.mapValues { Id(it) }.required("ids")
+
+    val handler =
+        ServerFilters.InitialiseRequestContext(RequestContexts()).then { request ->
+          val ids = idsQuery(request)
+          Response(Status.OK).json(ids)
+        }
+
+    val response = handler(Request(Method.GET, "/some/url?ids=1,2,3"))
+    response.status shouldBe Status.OK
+    val responseBody = response.json<List<Id>>()
+    responseBody shouldBe listOf(Id("1"), Id("2"), Id("3"))
+  }
+
+  @Test
+  fun `Bidirectional mapValues sets values correctly`() {
+    val idsQuery =
+        MultiValueQuery.mapValues(incoming = { Id(it) }, outgoing = { id -> id.value })
+            .required("ids")
+
+    val handler =
+        ServerFilters.InitialiseRequestContext(RequestContexts()).then { request ->
+          val ids = idsQuery(request)
+          Response(Status.OK).json(ids)
+        }
+
+    var request = Request(Method.GET, "/some/url")
+    request = idsQuery(listOf(Id("1"), Id("2")), request)
+
+    val response = handler(request)
+    response.status shouldBe Status.OK
+    val responseBody = response.json<List<Id>>()
+    responseBody shouldBe listOf(Id("1"), Id("2"))
+  }
+}


### PR DESCRIPTION
I discovered an issue in an endpoint where we wanted to accept a list
of values for a query parameter. I used http4k's `Query.multi`, which
appeared to work, but when I used the endpoint from our frontend (using
RTK Query), the query parameter was interpreted as a single string with
the values joined by a comma. I then found out that RTK Query passes
multi-value query params as a comma-separated string, i.e.
`?param=value1,value2`, while http4k expects them as separate params,
i.e. `?param=value1&param=value2`.

To fix this, I implemented a new `MultiValueQuery` lens, that accepts
both query param formats. I figured that this is something that other
projects may want to use as well (since most of us use http4k + RTK
Query), so this commit upstreams `MultiValueQuery`.