### PR TITLE
Update http4k and bump major version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,14 +19,14 @@
   <name>${project.artifactId}</name>
 
   <properties>
-    <major-version>5</major-version>
+    <major-version>6</major-version>
     <revision>${major-version}.local-SNAPSHOT</revision>
 
     <java.version>21</java.version>
     <kotlin.compiler.jvmTarget>${java.version}</kotlin.compiler.jvmTarget>
     <kotlin.compiler.apiVersion>2.1</kotlin.compiler.apiVersion>
 
-    <http4k.version>6.28.1.0</http4k.version>
+    <http4k.version>6.31.1.0</http4k.version>
     <kotlinx-serialization.version>1.10.0</kotlinx-serialization.version>
     <liflig-logging.version>3.20260204.135728</liflig-logging.version>
     <liflig-public-exception.version>2.20251121.121333</liflig-public-exception.version>


### PR DESCRIPTION
Http4k renamed tracingFiltersOpenTelemetryExtensions.kt to httpOpenTelemetryTracing.kt in 6.29.0.0. This file contains the function ServerFilters.OpenTelemetryTracing(), that liflig-http4k-setup uses. As the function was not renamed or moved to another package, the qualified name is still the same, but the compiled JVM class name of this function is changed, breaking compatibility between versions at runtime. This means code compiles fine against either version, but a JAR compiled against http4k 6.28 or below will crash with NoClassDefFoundError when paired with http4k 6.29 or above at runtime, and vice versa. 

Consumers must upgrade liflig-http4k-setup and http4k together.